### PR TITLE
Fix missing "new" keyword when throwing exceptions

### DIFF
--- a/basiclti/php-simple/ims-blti/OAuth.php
+++ b/basiclti/php-simple/ims-blti/OAuth.php
@@ -127,7 +127,7 @@ class OAuthSignatureMethod_RSA_SHA1 extends OAuthSignatureMethod {
     // (3) some sort of specific discovery code based on request
     //
     // either way should return a string representation of the certificate
-    throw Exception("fetch_public_cert not implemented");
+    throw new Exception("fetch_public_cert not implemented");
   }
 
   protected function fetch_private_cert(&$request) {
@@ -135,7 +135,7 @@ class OAuthSignatureMethod_RSA_SHA1 extends OAuthSignatureMethod {
     // (1) do a lookup in a table of trusted certs keyed off of consumer
     //
     // either way should return a string representation of the certificate
-    throw Exception("fetch_private_cert not implemented");
+    throw new Exception("fetch_private_cert not implemented");
   }
 
   public function build_signature(&$request, $consumer, $token) {


### PR DESCRIPTION
Credit goes to @marinaglancy for spotting these while peer-reviewing https://tracker.moodle.org/browse/MDL-59362